### PR TITLE
Update the "Community" page:

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -15,20 +15,21 @@ at Google Groups to discuss Slick or get help with its use. There are also tags 
 Please use the [issue tracker](http://github.com/slick/slick/issues) at GitHub
 to report bugs and issues.
 
-## Project Plan
-
-You can find our [project plan](https://www.assembla.com/spaces/typesafe-slick/milestones)
-and work items at Assembla.
-
 ## Get Involved
 
-Even better than bug reports and feature requests are patches and pull
-requests, so clone the Slick git repository from
-<http://github.com/slick/slick> and get started. Slick is easy to build and
-test, requiring only Java 6, git and
-[sbt](http://code.google.com/p/simple-build-tool/) 0.12.
+Do you have an interesting use case or code sample that could help others?
+You can share it easily by contributing a
+[Typesafe Activator Template](http://typesafe.com/activator/template/contribute)
 
-You will also have to sign the
+## Hack on Slick
+
+Working on the Slick codebase is easy. Simply clone the Slick git repository from
+<http://github.com/slick/slick> and get started. All you need is Java 6, git and
+[sbt](http://www.scala-sbt.org/) 0.13. The Slick source code has all embedded
+databases preconfigured for unit tests, so you can run a comprehensive test suite
+without any further setup.
+
+We always welcome 3rd-pary pull requests for Slick. Note that you will have to sign the
 [Typesafe Contributor License Agreement](https://www.typesafe.com/contribute/cla)
 (takes two minutes on-line) before we can accept your contributions.
 


### PR DESCRIPTION
- Remove link to old Assembla project (we're using github exclusively)
- Change the "Get Involved" section to point to Activator first. We
  want to encourage people to create Activator Templates instead of
  submitting PRs for slick-examples.

Review by @jamesward
