### PR TITLE
Updated “Learning Slick” link to Slick 2 version by Adam Mackler

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ contains a ready-to-run sbt project with simple, documented Slick programs.
 
 ## 3rd-Party Documentation
 
-* [Learning Slick](http://mackler.org/LearningSlick/) - A tutorial by Adam Mackler
+* [Learning Slick](https://mackler.org/LearningSlick2/) - A tutorial by Adam Mackler
 * [Blog posts / extensions](https://github.com/slick/slick/issues/478) - An unsorted list of 3rd party publications on Slick (code or text).
 
 ## Screencasts


### PR DESCRIPTION
Learning Slick by Adam Mackler has been updated to Slick 2 (and also removed the old version which now 404s).

Updated the link to the new one.
