### PR TITLE
Add community docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -72,15 +72,39 @@ title: Documentation
 * [Slick Codegen Example](https://github.com/slick/slick-codegen-example)
 * [Slick Codegen Customization Example](https://github.com/slick/slick-codegen-customization-example)
 
+## Extensions
+
+The official Play plugin for Slick:
+
+- [Github project](https://github.com/playframework/play-slick)
+- [Wiki](https://github.com/playframework/play-slick/wiki)
+
+## Third-party Extensions
+
+This is a list of third-party Slick extension projects we know of.
+We cannot guarantee for the quality or that they represent our view of things.
+Please add more projects to the list using a github pull request, if you think others can benefit from them. 
+
+- [Slick Joda Date mapper](https://github.com/tototoshi/slick-joda-mapper) - Enables you to use joda-time with Slick. You can persist DateTime, Instant, LocalDateTime, LocalDate, LocalTime, DateTimeZone with Slick.
+
+- [Slick Postgres extensions](https://github.com/tminglei/slick-pg) - Slick extensions for PostgreSQL, to support a series of pg data types and related operators/functions.
+
+- [Generic DAO for Slick projects](https://github.com/rcavalcanti/slick-dao) - Slick extensions for record lifecycle management.
+
 ## Books
 
 [![Essential Slick book cover]({{ site.url }}/resources/images/essential-slick-cover.png)](http://underscore.io/books/essential-slick/)
 
 ## 3rd-Party Documentation
 
-* [Essential Slick](http://underscore.io/books/essential-slick/) - book designed to help developers become productive with Slick quickly.
-* [Learning Slick](https://mackler.org/LearningSlick2/) - A tutorial by Adam Mackler
-* [Blog posts / extensions](https://github.com/slick/slick/issues/478) - An unsorted list of 3rd party publications on Slick (code or text).
+The following contains a list of Slick related third-party blog articles and documentation we know of:
+
+* [Slick 3](third-party-slick-3)
+* [Slick 2](third-party-slick-2)
+* [Slick 1](third-party-slick-1)
+
+We cannot guarantee for the quality of the above, or that they represent our view of things.
+Please add more entries using a github pull request, if they can teach people something about Slick.
 
 ## Screencasts
 

--- a/docs/third-party-slick-1.md
+++ b/docs/third-party-slick-1.md
@@ -1,0 +1,83 @@
+---
+layout: doc
+title: 3rd-Party Documentation for Slick 1
+---
+
+This is a list of Slick 1 related third-party blog articles and documentation we know of.
+We cannot guarantee for the quality or that they represent our view of things.
+Please add more entries using a github pull request, if they can teach people something about Slick.
+
+Many useful discussions can also be found in the [Slick google group](https://groups.google.com/forum/#!forum/scalaquery)
+and on [Stackoverflow](http://stackoverflow.com/questions/tagged/slick).
+
+## Typesafe / EPFL gists
+
+- 2014-03 [Nested entity mapping with Slick 1.x](https://gist.github.com/cvogt/9519186) *by cvogt*
+
+## Third-party translations
+
+- [日本の / Japanese](https://github.com/krrrr38/slick-doc-ja)
+
+## Articles
+
+- 2013-12 [Slick monadic transactions]( https://gist.github.com/aloiscochard/7731519 ) *by Alois Cochard*
+
+- 2013-11-26 [Akka based worker pool for asynchronous and non-blocking execution]( http://tech.kinja.com/akka-based-worker-pool-for-asynchronous-and-non-blockin-1471475956 ) *by Mikolaj Szabó, Kinja*
+
+- 2013 [Proper configuration of H2 with Scala Slick for testing]( https://coderwall.com/p/a2vnxg )
+
+- 2013-11-21 [Mapping Slick query results to case classes 1.0.1]( http://blog.lunatech.com/2013/11/21/slick-case-classes ) *by Peter Hilton*
+
+- 2013-10-04 [Executing database queries with Slick 1.0.1](http://blog.lunatech.com/2013/10/04/play-slick-executing-queries) *by Peter Hilton*
+
+- 2013-09-25 [Defining database queries with Slick 1.0.1]( http://blog.lunatech.com/2013/09/25/play-slick-defining-queries ) *by Peter Hilton*
+
+- 2013-08-29 [Using Play framework database evolutions with Slick 1.0.1]( http://blog.lunatech.com/2013/08/29/play-slick-evolutions ) *by Peter Hilton*
+
+- 2013-08-21 [Defining database table columns with Slick 1.0.1]( http://blog.lunatech.com/2013/08/21/slick-column-definitions ) *by Peter Hilton*
+
+- 2013-08-13 [Using the Scala console with Play and Slick 1.0.1]( http://blog.lunatech.com/2013/08/13/play-slick-scala-console ) *by Peter Hilton, Lunatech*
+
+- 2013-08-09 [scala - slick - left join]( http://tikokelottlegyenviz.blogspot.ch/2013/08/scala-slick-left-join.html ) *by péntek*
+
+- 2013-08-08 [Getting started with Play and Slick 1.0.1]( http://blog.lunatech.com/2013/08/08/play-slick-getting-started ) *by Peter Hilton*
+
+- 2013-08-01 [Building REST Service with Scala]( http://sysgears.com/articles/building-rest-service-with-scala/ ) *by Oleg, SysGears*
+
+- 2013-07-18 [How to Update Entire Database Record Using Slick]( http://sysgears.com/notes/how-to-update-entire-database-record-using-slick/ ) *by Oleg, SysGears*
+
+- 2013-07-18 [Using Database Dialects within Play Framework]( http://eng.42go.com/using-database-dialects-with-in-play-framework/ ) *by Eishay Smith, fortytwo*
+
+- 2013-07-17 *Warning, misleading about read-only* [Managing Scala Slick Database Drivers & Type-Safeing Session Concurrency]( http://eng.42go.com/scala-slick-database-drivers-type-safing-session-concurrency/ ) *by Eishay Smith, fortytwo*
+
+- 2013-07-08 [CRUD trait for Slick models in the Play! framework]( http://logician.eu/2013/07/08/crud-trait-for-slick-models-in-the-play-framework/ ) *by Manuel*
+
+- 2013-07-04 [Play 2, SecureSocial and Slick]( http://blog.lunatech.com/2013/07/04/play-securesocial-slick ) *by Sietse de Kaper, Lunatech*
+
+- 2013-06 [A Slick Tool for Database Schema Generation]( https://bhudgeons.telegr.am/blog_posts/slick-tool-for-db-schema-generation ) *by Brandon Hudgeons*
+
+- 2013-06-08 [ORM-like model objects with Slick]( http://tech.kinja.com/orm-like-model-objects-with-slick-1004286329 ) *by Eric*
+
+- 2013-04-19 [Why We Started Using PostgreSQL With Slick Next To MongoDB]( http://www.plotprojects.com/why-we-use-postgresql-and-slick/ ) *by Mark van der Tol, Plot Projects*
+
+- 2013-04-07 [Slick connection pooling]( http://fernandezpablo85.github.io/2013/04/07/slick_connection_pooling.html ) *by Fernandez Pablo*
+
+- 2013-02-24 [Introduction to Slick – plain SQL usage]( http://wix.io/2013/02/24/introduction-to-slick-plain-sql-usage/ ) *by Kfir Bloch, Wix*
+
+- 2013-01-03 [Database Record Updates with Slick in Scala (and Play)]( http://madnessoftechnology.blogspot.ch/2013/01/database-record-updates-with-slick-in.html ) *by Alex Turner*
+
+- 2012-12-02 [Starting with Slick – Part 1]( http://crisdev.wordpress.com/2012/12/06/starting-with-slick-part-1/ ) *by Cristian Boariu*
+
+## Example projects
+
+- [Hello Scalatra Slick](https://github.com/spatzle/hello-scalatra-slick) - An extremely simple example to help one get started in scalatra and slick with mysql
+
+- [playcrud by ThomasAlexandre](https://github.com/ThomasAlexandre/playcrud) - Reverse engineer a jdbc database into a scala play2 web app using slick as db access library.
+
+- [slickcrudsample by ThomasAlexandre](https://github.com/ThomasAlexandre/slickcrudsample) - A sample CRUD application for the Play 2.1 Framework using SLICK as its database access library.
+
+- [tiny-world slick example by tpolecat](https://github.com/tpolecat/tiny-world/tree/master/src/test/scala/org/tpolecat/tiny/world/example/slick).
+calaQuery_Nested
+
+- [ScalaQuery Nested](https://github.com/tim-group/scalaquery_nested) - Safely manage nested sessions & transactions in Slick.
+

--- a/docs/third-party-slick-2.md
+++ b/docs/third-party-slick-2.md
@@ -1,0 +1,85 @@
+---
+layout: doc
+title: 3rd-Party Documentation for Slick 2
+---
+
+This is a list of Slick 2 related third-party blog articles and documentation we know of.
+We cannot guarantee for the quality or that they represent our view of things.
+Please add more entries using a github pull request, if they can teach people something about Slick.
+
+Many useful discussions can also be found in the [Slick google group](https://groups.google.com/forum/#!forum/scalaquery)
+and on [Stackoverflow](http://stackoverflow.com/questions/tagged/slick).
+
+## Typesafe / EPFL gists
+
+- 2014-05-15 [Inject custom SQL instead of the Slick produced SQL](https://gist.github.com/cvogt/d9049c63fc395654c4b4) *by cvogt*
+
+- 2014-02 [Slick app architecture cheat sheet](https://gist.github.com/cvogt/9239494)
+
+- 2014-02 [MaybeFilter: concisely write queries in Slick with many optional constraints](https://gist.github.com/cvogt/9193220) *by ruescasd and cvogt*
+
+## Third-party translations
+
+- [日本の / Japanese](https://github.com/krrrr38/slick-doc-ja)
+
+## Books
+
+* [Essential Slick](http://underscore.io/books/essential-slick/) - book designed to help developers become productive with Slick quickly.
+* [Learning Slick](https://mackler.org/LearningSlick2/) - A tutorial by Adam Mackler.
+
+## Articles
+
+- 2015-02-24 [6 months with Slick](http://movio.co/blog/6-months-slick/) - Experience report from Movio.
+
+- 2015-01-27 [The Rough Experience with Slick](http://blog.scalac.io/2015/01/27/rough-experience-with-slick.html) - notes from ScalaC.
+
+- 2014-07-14 [Embracing Your Rows With Slick](http://www.strongtyped.io/blog/2014/07/18/embracing-your-rows-with-slick/) - follow-up of Renato Cavalcanti's talk "Slick in the field, learning to forget ORM" presented at ScalaDays 2014. Video also included on that page.
+
+- 2014-02-27 [Clean and re-usable Slick modules](http://eng.42go.com/clean-and-re-usable-slick-modules/) *by Andrew Conner, fortytwo*
+
+- 2014-02-11 [Database patterns in Scala](http://eng.42go.com/database-patterns-in-scala/) *by Andrew Conner, fortytwo*
+
+- 2014-01-20 [Scala Slick 2.0 for multi-database](http://blog.knoldus.com/2014/01/20/scala-slick-2-0-for-multi-database/) *by Satendra Kumar, Knoldus*
+
+- 2013-12-29 [Play Framework Evolutions with Slick 2.0 Code Generator](http://blog.papauschek.com/2013/12/play-framework-evolutions-slick-2-0-code-generator/) *by Christian Papauschek*
+
+- 2013-12-11 [CRUD trait for Slick 2.0](http://crisdev.wordpress.com/2013/12/11/crud-trait-for-slick-2-0/) *by Cristian Boariu*
+
+- 2006-06-17 [The Functional-Relational Impedance Match](http://blog.enfranchisedmind.com/2006/06/the-functional-relational-impedance-match/)
+
+## Tips and tricks
+
+- [Solution for full text search in mysql](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/scalaquery/J69iImyT3nE/pPlm_gfjvhsJ)
+
+- How to [use db constants and functions that use keywords as arguments](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/scalaquery/w7DpCLzoo0E/0QlhqKKOqksJ)
+
+- [Advice on Slick connection pool size](https://groups.google.com/forum/#!msg/scalaquery/-mwrq3KHdCM/dG9HVZBMcNMJ)
+
+- [SingleThreadSlickApi.scala](https://gist.github.com/timcharper/037fb54fd788d42ad94f)
+
+## Plugins and extensions
+
+- [Slick Code Generation Plugin](https://github.com/muuki88/sbt-slick) - This plugin allows you to easily generate slick Table schemas. Take a look at the test-project for example configurations.
+
+- [Slick Macros](https://github.com/ebiznext/slick-macros) - reducing boilerplate code needed in Slick.
+
+
+## Example projects
+
+
+- [GitBucket](https://github.com/gitbucket/gitbucket) - GitBucket is a GitHub clone powered by Scala which has easy installation and high extensibility.
+
+- [Slick Testing](https://github.com/drstevens/slick-testing) - It's not immediately obvious how to write a Slick implementation without being tied to a specific driver. This is my attempt. Credit to Dirceu Semighini Filho who posted some sample code in a thread on the Slick Mailing List.
+
+- [SlickDroid](https://github.com/zbsz/slickdroid) - SlickDroid is an implementation of Android backend for Slick, it allows you to use Slick in Android project written in Scala.
+
+- [Slick Android Example](https://github.com/pulsation/slick-android-example).
+
+- [SlickChair](https://github.com/SlickChair/SlickChair) - SlickChair is an open-source conference management system written in Scala. Built with the Play framework and the Slick database access library, SlickChair provides a highly flexible and extensible solution to manage a peer review process.
+
+- [Slick for Multiple Databases](https://github.com/satendrakumar06/slickformultipledatabases).
+
+- [Play Slick Examples from Lunatech](https://github.com/lunatech-labs/play-slick-examples) - A Play Framework application that demonstrates how to use Slick for database access.
+
+- [Slick 2 Code Generator and Play](https://github.com/papauschek/play-slick-evolutions) - This sample project shows how to integrate the Slick 2.0 code generator with the Play Framework Evolutions (database migrations).
+

--- a/docs/third-party-slick-3.md
+++ b/docs/third-party-slick-3.md
@@ -1,0 +1,41 @@
+---
+layout: doc
+title: 3rd-Party Documentation for Slick 3
+---
+
+This is a list of Slick 3 related third-party blog articles and documentation we know of.
+We cannot guarantee for the quality or that they represent our view of things.
+Please add more entries using a github pull request, if they can teach people something about Slick.
+
+Many useful discussions can also be found in the [Slick google group](https://groups.google.com/forum/#!forum/scalaquery)
+and on [Stackoverflow](http://stackoverflow.com/questions/tagged/slick).
+
+## Third-party translations
+
+- [日本の / Japanese](https://github.com/krrrr38/slick-doc-ja)
+
+## Books
+
+- [Essential Slick](http://underscore.io/books/essential-slick/) - book designed to help developers become productive with Slick quickly.
+
+## Articles
+
+- [Common Model Fields With Slick 3 (Part I)](http://gavinschulz.com/posts/2016-01-30-common-model-fields-with-slick-3-part-i.html).
+
+
+## Plugins
+
+- [Slick Code Generation Plugin](https://github.com/muuki88/sbt-slick) - This plugin allows you to easily generate slick Table schemas. Take a look at the test-project for example configurations.
+
+
+## Example projects
+
+- [Getting Started: Scala SQL DB access using Slick + PostgreSQL or MySQL](https://gist.github.com/timcharper/037fb54fd788d42ad94f) - This repository contains demo code for connecting to a SQL database using the Slick FRM.
+
+- [slick-generic-dao-example](https://github.com/voidcontext/slick-generic-dao-example) - Generic DAO example implementation for Slick 3.0.
+
+- [slick-for-production](slick-for-production).
+
+- [Happy Melly Teller](https://github.com/happymelly/teller) - Happy Melly Teller is a web system which supports Happy Melly's ecosystem and perfectly suits for any business or non-profit organization with similar network structure.  The platform allows to manage information about people, organizations, brands, licensees and so on. It also provides REST API for retrieving these objects from third-party apps and websites.
+
+


### PR DESCRIPTION
This PR supersedes PR https://github.com/slick/slick/pull/826 by taking the changes proposed for the Slick manual and moving them into the web site.  I've also included the links mentioned in comments on that PR. 

The documentation index page retains a "3rd Party Documentation" section, but it now links to a separate page for each version of Slick:

![untitled 5 2016-03-14 08-54-11](https://cloud.githubusercontent.com/assets/102661/13739327/775613fe-e9c2-11e5-8e31-8087f9e21274.png)

We could do the same for talks and other parts of the site, but this is a start...

For the record, @cvogt did the hard work in collating all the information - I've shuffled it about a bit.
