### PR TITLE
Added Courses section for 3rd party Slick 3 page

### DIFF
--- a/docs/third-party-slick-3.md
+++ b/docs/third-party-slick-3.md
@@ -18,6 +18,15 @@ and on [Stackoverflow](http://stackoverflow.com/questions/tagged/slick).
 
 - [Essential Slick](http://underscore.io/books/essential-slick/) - book designed to help developers become productive with Slick quickly.
 
+## Courses
+
+- [Scalanator](https://www.scalanator.io/courses) is a new browser-based training service.
+It contains a free introduction to Slick.
+N.b. the course and service are under development by the Scalanator team.
+
+- [Essential Slick](http://underscore.io/training/courses/essential-slick/) is a commercial training course.
+The course description page contains a free recording created for the hands-on workshop held at Scala Exchange in 2015.
+
 ## Articles
 
 - [Common Model Fields With Slick 3 (Part I)](http://gavinschulz.com/posts/2016-01-30-common-model-fields-with-slick-3-part-i.html).


### PR DESCRIPTION
Looks like this:

![3rd-party documentation for slick 3 slick 2016-07-05 10-51-51](https://cloud.githubusercontent.com/assets/102661/16580939/db66b49a-429e-11e6-89df-da249083abf5.png)
