### PR TITLE
Correct Japanese word for the Japanese language

### DIFF
--- a/docs/third-party-slick-3.md
+++ b/docs/third-party-slick-3.md
@@ -12,7 +12,7 @@ and on [Stackoverflow](http://stackoverflow.com/questions/tagged/slick).
 
 ## Third-party translations
 
-- [日本の / Japanese](https://github.com/krrrr38/slick-doc-ja)
+- [日本語 / Japanese](https://github.com/krrrr38/slick-doc-ja)
 
 ## Books
 


### PR DESCRIPTION
Not the adjective.
