### PR TITLE
Adds cookie banner and links to privacy/cookie poilcy

### DIFF
--- a/_includes/footerbar.html
+++ b/_includes/footerbar.html
@@ -3,7 +3,11 @@
 		<div class="row">
 			<div class="span12">
 				<div class="footerbar-copyright">
-					Copyright &copy; 2011-2016 <a href="http://lightbend.com">Lightbend, Inc.</a> &nbsp;&nbsp;-&nbsp;&nbsp; Slick is open source and available under a <a href="https://github.com/slick/slick/blob/master/LICENSE.txt">BSD-style license</a>
+					Slick is open source and available under a <a href="https://github.com/slick/slick/blob/master/LICENSE.txt">BSD-style license</a><br>
+					Copyright &copy; 2011-2019 <a href="http://lightbend.com">Lightbend, Inc.</a> | 
+					<a href="https://www.lightbend.com/legal/privacy">Privacy Policy</a> | 
+					<a href="https://www.lightbend.com/legal/cookie">Cookie Listing</a> | 
+					<a class="optanon-toggle-display">Cookie Settings</a>
 				</div>
 				<img src="{{ site.baseurl }}/resources/images/slick-logo-sm.png"/>
 			</div>

--- a/_includes/headerbottom.html
+++ b/_includes/headerbottom.html
@@ -1,4 +1,5 @@
-<script type="text/javascript">
+<!-- Google Analytics loads if and after user accepts cookies -->
+<script type="text/plain" class="optanon-category-2">
 
   var _gaq = _gaq || [];
   _gaq.push(['_setAccount', 'UA-23127719-3']);
@@ -10,22 +11,21 @@
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
 
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-  ga('create', 'UA-23127719-1', 'typesafe.com', {'allowLinker': true, 'name': 'tsTracker'});
-  ga('tsTracker.require', 'linker');
-  ga('tsTracker.linker:autoLink', ['typesafe.com','playframework.com','scala-lang.org','scaladays.org','spray.io','akka.io','scala-sbt.org','scala-ide.org']);
-  ga('tsTracker.send', 'pageview');
+  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-MQFHPFW');
+
 </script>
+
 <script type="text/javascript">
   (function() {
     var didInit = false;
     function initMunchkin() {
       if(didInit === false) {
         didInit = true;
-        Munchkin.init('558-NCX-702');
+        Munchkin.init('558-NCX-702', { 'asyncOnly': true, 'disableClickDelay': true });
       }
     }
     var s = document.createElement('script');

--- a/_includes/headertop.html
+++ b/_includes/headertop.html
@@ -23,6 +23,13 @@
     <!-- Jquery -->
     <script src="{{ site.baseurl }}/resources/javascript/jquery.js" type="text/javascript" ></script>
 
+    <!-- OneTrust Cookies Consent Notice (Production CDN, lightbend.com, en-US) start -->
+    <script src="https://cdn.cookielaw.org/consent/ae5fff26-6829-4430-a8ae-e7efb10d58bf.js" type="text/javascript" charset="UTF-8"></script>
+    <script type="text/javascript">
+      function OptanonWrapper() { }
+    </script>
+    <!-- OneTrust Cookies Consent Notice (Production CDN, lightbend.com, en-US) end -->
+
     <!-- prettyprint js to prepend generated pre/code tags -->
     <script type="text/javascript">
       function styleCode() {

--- a/resources/stylesheets/base.css
+++ b/resources/stylesheets/base.css
@@ -71,12 +71,14 @@ nav.mainnav li:hover a { color: white; text-shadow:1px 1px 1px rgba(0,0,0,0.8); 
 
 .main-content::after { content:"";position:absolute;bottom:0;left:0;width:100%;height:10px;z-index:2;-webkit-box-shadow:0 5px 8px rgba(0,0,0,0.35);-moz-box-shadow:0 5px 8px rgba(0,0,0,0.35);box-shadow:0 5px 8px rgba(0,0,0,0.35)}
 .secondary::after { content:"";position:absolute;bottom:0;left:0;width:100%;height:10px;z-index:2;-webkit-box-shadow:0 5px 8px rgba(0,0,0,0.35);-moz-box-shadow:0 5px 8px rgba(0,0,0,0.35);box-shadow:0 5px 8px rgba(0,0,0,0.35)}
-.footerbar { clear: both; background: #747474; width: 100%; color: rgba(255, 255, 255, 0.65); text-shadow: 0 1px 0 rgba(0, 0, 0, 0.4); font-size: 13px; }
-.footerbar-copyright { float: left; text-align: right; padding-top: 15px; padding-bottom: 15px; }
+.footerbar { clear: both; background: #747474; width: 100%; color: rgba(255, 255, 255, 0.65); text-shadow: 0 1px 0 rgba(0, 0, 0, 0.4); font-size: 13px; padding: 30px 0; }
+.footerbar-copyright { float: left; text-align: left; line-height: 2; }
 .footerbar img { float: right; padding-top: 10px; }
 .footerbar a {color: rgba(255, 255, 255, 0.6); text-decoration: underline; }
 .footerbar a:hover { color: rgba(255, 255, 255, 0.8); }
 .footerbar a:visited { color: rgba(255, 255, 255, 0.2); text-decoration: underline; }
+
+.optanon-toggle-display:hover {cursor: pointer}
 
 .twtr-widget {
   margin-top: 3em;


### PR DESCRIPTION
This adds Lightbend cookie banner and links to the privacy and cookie policy. By default Google Analytics is now turned off until a user accept cookies. 

As a result a drop in analytics numbers is to be expected. It is recommended to add an annotation in your google analytics property noting that the cookie banner was added on the date this change goes live. 

Also an old tsTracker google analytics script has been replaced with Google Tag Manager.

Footer has been refactored slightly now that more content/links have been added