### PR TITLE
Update the domain to scala-slick.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-slick.lightbend.com
+scala-slick.org

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Install Jekyll using the gem package manager:
 
 ## Building & Viewing ##
 
-Launch the Jekyll server with auto-regeneration and an overwritten baseurl (so that it doesn't use the one from `_config.yml`):
+Launch the Jekyll server with auto-regeneration
 
-    jekyll serve --watch --baseurl ''
+    jekyll serve --watch
 
 The generated site is available at `http://localhost:4000`
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,5 @@
 title: "Slick"
 description: "Scala Language-Integrated Connection Kit"
-baseurl: "http://slick.lightbend.com"
 markdown: kramdown
 
 exclude:


### PR DESCRIPTION
Remove the absolute baseurl configuration, which isn't needed.

We'll need to hold off from merging until the DNS changes are made.

Resolves slick/slick#2082.