### PR TITLE
Use HTTPS for Google Fonts

### DIFF
--- a/_includes/headertop.html
+++ b/_includes/headertop.html
@@ -11,8 +11,8 @@
     <link rel="icon" type="image/png" href="{{ site.baseurl }}/resources/favicon.ico">
 
     <!--Google fonts API-->
-    <link href='http://fonts.googleapis.com/css?family=Lato:400,400italic' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans+Condensed:700' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Lato:400,400italic' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans+Condensed:700' rel='stylesheet' type='text/css'>
 
     <!-- CSS -->
     <link rel="stylesheet" href="{{ site.baseurl }}/resources/stylesheets/bootstrap.min.css" type="text/css" />


### PR DESCRIPTION
This allows the site to load over HTTPS without a mixed content error.