### PR TITLE
Release 3.3.3 blog post

### DIFF
--- a/news/_posts/2020-09-09-slick-3.3.3-released.md
+++ b/news/_posts/2020-09-09-slick-3.3.3-released.md
@@ -1,0 +1,24 @@
+---
+layout: news
+title: Slick 3.3.3
+author: Renato Cavalcanti
+---
+We have just released Slick 3.3.3
+You can find the source code here: <https://github.com/slick/slick/tree/v3.3.0>.
+Builds for Scala 2.11, 2.12 and 2.13 are available from Maven Central, as usual.
+
+## Highlights
+
+This release includes a few bug fixes and improvements:
+
+* Deterministic create and createIfNotExists (https://github.com/slick/slick/pull/2127 by https://github.com/sebastian-alfers)
+* Invalid query generated using OracleDriver for filter with Option column (https://github.com/slick/slick/pull/2059 by https://github.com/alexFrankfurt)
+* New Cookbook section in documentation (https://github.com/slick/slick/pull/2061 by https://github.com/d6y)
+* Optimized `DISTINCT` and `DISTINCT ON` generation (https://github.com/slick/slick/pull/2097 by https://github.com/shmishleniy)
+
+See GitHub for the [full list](https://github.com/slick/slick/compare/v3.3.0...v3.3.3) of commits.
+
+## Credits
+This release contains contributions by the following committers since 3.3.0:
+
+[Sebastian Alfers](https://github.com/sebastian-alfers), [Alex Frankfurt](https://github.com/alexFrankfurt), [Richard Dallaway](https://github.com/d6y), [Andrii Stasiuk](https://github.com/shmishleniy), [Mark Petruska](https://github.com/mpetruska), [Heikki Vesalainen](https://github.com/hvesalai), [PJ Fanning](https://github.com/pjfanning), [Marcos Pereira](https://github.com/marcospereira), [Ruud Welling](https://github.com/WellingR) and [Renato Cavalcanti](https://github.com/renatocaval)


### PR DESCRIPTION
The release is already out and the docs are updated. This is includes only a blog post with the highlights for 3.3.3.