### PR TITLE
Add Slick 3.5 announcement

### DIFF
--- a/_includes/frontpage.html
+++ b/_includes/frontpage.html
@@ -40,6 +40,11 @@
     <div class="container" id="lower">
       <div class="row">
         <div class="span8">
+          <p>
+            <a href="https://index.scala-lang.org/slick/slick/slick">
+              <img alt="slick Scala version support" src="https://index.scala-lang.org/slick/slick/slick/latest-by-scala-version.svg?platform=jvm" />
+            </a>
+          </p>
 
           {% capture readme %}
             {% include_file "https://raw.githubusercontent.com/slick/slick/main/README.md"

--- a/news/_posts/2024-11-30-slick-3.5.x-is-here.md
+++ b/news/_posts/2024-11-30-slick-3.5.x-is-here.md
@@ -1,0 +1,24 @@
+---
+layout: news
+title: Slick 3.5.x is here!
+author: Naftoli Gugenheim
+---
+
+Slick 3.5.0 was released earlier this year with support for Scala 3! As of Slick 3.5.2 a minimum Java version of 11 is now required.
+
+The latest docs are at <https://scala-slick.org/doc/stable/>.
+
+
+## How to upgrade
+
+In many cases, upgrading should just be a matter of setting the version to `3.5.2` in your build files. (Or, give [Scala Update](https://github.com/kitlangton/scala-update) a try.)
+However, a number of deprecated APIs have been dropped in 3.5.0. You should fix any deprecation warnings before upgrading. See [the upgrade guide](https://scala-slick.org/doc/prerelease/upgrade.html#upgrade-from-3-4-x-to-3-5-0) in case any changes do affect you.
+
+
+## Community
+
+ - Ask questions and make suggestions at <https://github.com/slick/slick/discussions>
+ - Report bugs at <https://github.com/slick/slick/issues>
+ - Follow progress of pull requests and join the conversation at <https://github.com/slick/slick/pulls> &mdash; or send your own improvements!
+ - Chat on the #slick channel of the main Scala Discord at <https://discord.gg/yQheBhUtAa>
+ - Help fund Slick development by sponsoring me at <https://github.com/sponsors/nafg>


### PR DESCRIPTION
There was a comment in a Reddit thread earlier that mentioned the Slick site was stale, so I did up a quick announcement for 3.5.x things. 

I also added a version badge to the home page so there is _something_ always linking to the latest version. Home page now looks like: 

![image](https://github.com/user-attachments/assets/76c562f0-d9e4-4d71-b752-beed9265e068)
